### PR TITLE
util for generating nested vnodes

### DIFF
--- a/microh.js
+++ b/microh.js
@@ -18,13 +18,21 @@ const microh = (h, classKey = 'className') => {
     return tag || 'div'
   }
 
-  return (tag, ...children) => {
+  const m = (tag, ...children) => {
     let attrs = children[0]
     if (attrs && typeof attrs == 'object' && !isArray(attrs) && (!attrs[tagKey] || !attrs[attrKey]))
       children.shift()
     else attrs = {}
     return h(parseTag(tag, attrs), attrs, children)
   }
+  m.n = (tags, ...children) => {
+    const parts = tags.split('>')
+    return parts.reduceRight(
+      (child, tag) => m(tag.trim(), child),
+      m(parts.pop().trim(), ...children)
+    )
+  }
+  return m
 }
 
 export default microh

--- a/test.js
+++ b/test.js
@@ -73,4 +73,20 @@ o.spec('microh', () => {
       props: 'some'
     })
   })
+  o('h.n works', () => {
+    const node = h.n('div.div > p.p > span.span', { title: 'world' }, 'hello')
+    o(node).deepEquals({
+      tag: 'div',
+      attrs: { className: 'div' },
+      children: [
+        {
+          tag: 'p',
+          attrs: { className: 'p' },
+          children: [
+            { tag: 'span', attrs: { className: 'span', title: 'world' }, children: ['hello'] }
+          ]
+        }
+      ]
+    })
+  })
 })


### PR DESCRIPTION
- exposed through `n` property of m instance

An idea... I like it and use it in a few projects, especially when I'm using a css library like bootstrap or bulma, since they use so many nested html elements with just classes.

Would grow library size by ~54b.

Usage looks like this:
```js
const m = microh(preact.h)
const vnodes = m.n('li.list-item > a.menu-link', { href: '#' })
// vnodes === m('li.list-item', m('a.menu-link', { href: '#' }))
```